### PR TITLE
update date-format to 3.0 to fix ISO8601 with TZ offset output (try to fix #26)

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "lerna": "3.18.4",
     "colors": "^1.3.3",
-    "date-format": "^2.0.0",
+    "date-format": "^3.0.0",
     "semver": "^5.6.0",
     "streamroller": "^1.0.3",
     "tslib": "1.10.0",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "colors": "^1.3.3",
-    "date-format": "^2.0.0",
+    "date-format": "^3.0.0",
     "semver": "^5.6.0",
     "streamroller": "^1.0.3",
     "tslib": "1.10.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4670,6 +4670,11 @@ date-format@^2.0.0:
   resolved "https://registry.yarnpkg.com/date-format/-/date-format-2.1.0.tgz#31d5b5ea211cf5fd764cd38baf9d033df7e125cf"
   integrity sha512-bYQuGLeFxhkxNOF3rcMtiZxvCBAquGzZm6oWA1oZ0g2THUzivaRhv8uOhdr19LmoobSOLoIAxeUK2RdbM8IFTA==
 
+date-format@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/date-format/-/date-format-3.0.0.tgz#eb8780365c7d2b1511078fb491e6479780f3ad95"
+  integrity sha512-eyTcpKOcamdhWJXj56DpQMo1ylSQpcGtGKXcU0Tb97+K56/CF5amAqqqNj0+KvA0iw2ynxtHWFsPDSClCxe48w==
+
 dateformat@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"


### PR DESCRIPTION
## Informations

Type | Status | Migration
---|---|---
Fix | Ready | No

****

## Description
Bump date-format ^2.0.0 to ^3.0.0.

## Todos

- [x] Unit tests
- [x] Try it with some real code
- [ ] Coverage
- [ ] Example
- [ ] Documentation
